### PR TITLE
Garena support

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -118,6 +118,11 @@ getInstallPath = (cb) ->
     if fs.existsSync(process.cwd() + '/lol.launcher.exe')
       GLOBAL.lolInstallPath = process.cwd() + '/Config/Champions/'
       cb null
+      
+    # Also check League of Legends.exe in case it's a Garena installation.
+    else if fs.existsSync(process.cwd() + '/League of Legends.exe')
+      GLOBAL.lolInstallPath = process.cwd() + '/Config/Champions/'
+      cb null
 
     else if fs.existsSync('C:/Riot Games/League Of Legends/lol.launcher.exe')
       GLOBAL.lolInstallPath = 'C:/Riot Games/League Of Legends/Config/Champions/'


### PR DESCRIPTION
Garena LoL installations does not include lol.launcher.exe. Because of that, I've added a check for League of Legends.exe in addition to lol.launcher.exe so Garena installation can be detected.