### PR TITLE
Minor grammar and phrasing changes

### DIFF
--- a/app/views/main.html
+++ b/app/views/main.html
@@ -23,18 +23,18 @@
 
     <div class="ui checkbox left">
       <input type="checkbox" id="options_splititems" />
-      <label class="options_tooltip" data-content="You'll have two menu options in game, one for Most Frequent, and Highest Wins">Split Up Item Sets</label>
+      <label class="options_tooltip" data-content="Create separate item sets for Most Frequent and Highest Win %">Split Up Item Sets</label>
     </div>
 
     <div class="ui checkbox left">
       <input type="checkbox" id="options_skillsformat" />
-      <label class="options_tooltip" data-content="Instead of Q.W.E.Q.W.R.Q.W.Q.W ect">Use short Skills (Q>W>E) instead of full (Q.W.E.Q.W)</label>
+      <label class="options_tooltip" data-content="Instead of Q.W.E.Q.W.R.Q.W.Q.W ect">Use Shorthand for Skill Order (Q>W>E)</label>
     </div>
 
     <div class="with_dropdown">
       <div class="ui checkbox left">
         <input type="checkbox" id="options_consumables" checked />
-        <label class="options_tooltip" data-content="By disabling Consumables you'll lose Highest Win Skill priorities">Enable Consumables</label>
+        <label class="options_tooltip" data-content="By disabling consumables, you'll lose the Highest Win % skill order">Enable Consumables</label>
       </div>
       <div class="ui icon bottom right pointing dropdown button">
         <i class="small wrench icon"></i>
@@ -53,7 +53,7 @@
     <div class="with_dropdown">
       <div class="ui checkbox left">
         <input type="checkbox" id="options_trinkets" checked  />
-        <label class="options_tooltip" data-content="By disabling Trinkets you'll lose Most Frequient Skill priorities">Enable Trinkets</label>
+        <label class="options_tooltip" data-content="By disabling trinkets, you'll lose the Most Frequent skill order">Enable Trinkets</label>
       </div>
       <div class="ui icon bottom right pointing dropdown button">
         <i class="small wrench icon"></i>
@@ -70,7 +70,7 @@
 
     <div class="ui checkbox left">
       <input type="checkbox" id="options_locksr" />
-      <label class="options_tooltip" data-content="Champion.GG item sets will only be available on Summoners Rift">Lock ChampionGG Item Sets to Summoners Rift</label><br />
+      <label class="options_tooltip" data-content="Champion.gg item sets will only be available on Summoner's Rift">Lock Champion.gg Item Sets to Summoner's Rift</label><br />
     </div>
 
   </div>


### PR DESCRIPTION
This PR includes a few miscellaneous changes regarding the text in the main UI.

- **Change "skill priority" to "skill order"**. Champion.gg uses this phrasing and I feel as though it's more commonly used in general as well.
- **Shorten text for skill order option**. The hover-over text already describes the longer version of the skill order, so I think this looks a little cleaner.
- `ChampionGG` and `Champion.GG` -> `Champion.gg`
- `Summoners Rift` -> `Summoner's Rift`
- `Highest Win` -> `Highest Win %`.