### PR TITLE
Linux fixes

### DIFF
--- a/src/preferences.js
+++ b/src/preferences.js
@@ -24,6 +24,8 @@ class Preferences {
     let preference_dir;
     if (process.platform === 'darwin') {
       preference_dir = path.join(process.env.HOME, 'Library/Application Support/Championify/');
+    } else if (process.platform === 'linux') {
+      preference_dir = path.join(process.env.HOME, 'Championify/');
     } else {
       preference_dir = path.join(process.env.APPDATA, 'Championify');
     }

--- a/tasks/electron.js
+++ b/tasks/electron.js
@@ -73,7 +73,8 @@ function _processZipEntry(zip, dest, entry) {
   }
 }
 
-function _zipExtract(zipfile, dest = './') {
+function _zipExtract(zipfile, dest) {
+  dest = (typeof dest !== 'undefined') ? dest : './';
   fs.mkdirsSync(dest);
   const zip_entries = [];
 
@@ -89,7 +90,8 @@ function _zipExtract(zipfile, dest = './') {
     });
 }
 
-function download(url, download_path, overwrite = false) {
+function download(url, download_path, overwrite) {
+  overwrite = (typeof overwrite !== 'undefined') ? overwrite : false;
   if (overwrite) fs.removeSync(download_path);
   if (fs.existsSync(download_path)) return Promise.resolve();
 


### PR DESCRIPTION
Today I made the new championify 2 work on GNU/Linux without wine.

On my linux distribution (most up-to-date Debian) the javascript default parameter syntax is still not supported during npm install for some reason, so I added the old syntax for default parameters.

The preference_dir change is kind of self explanatory.

After these changes I managed to use Championify on my linux with "npm run dev" command and specifying the game folder from my wine installation, everything worked flawlessly!

Thanks for this project!