### PR TITLE
Now using new launcher when available

### DIFF
--- a/src/path_manager.js
+++ b/src/path_manager.js
@@ -17,13 +17,12 @@ function findInstallPath() {
   if (process.platform === 'darwin') {
     if (fs.existsSync('/Applications/League of Legends.app')) {
       return this.setInstallPath(null, '/Applications/League of Legends.app/', 'Contents/LoL/Config/Champions/');
-    } else if (fs.existsSync('${user_home}/Applications/League of Legends.app')) {
-      return this.setInstallPath(null, '${user_home}/Applications/League of Legends.app/', 'Contents/LoL/Config/Champions/');
+    } else if (fs.existsSync(`${user_home}/Applications/League of Legends.app`)) {
+      return this.setInstallPath(null, `${user_home}/Applications/League of Legends.app/`, 'Contents/LoL/Config/Champions/');
     }
   } else if (fs.existsSync('C:/Riot Games/League Of Legends/LeagueClient.exe')) {
     return this.setInstallPath(null, 'C:/Riot Games/League Of Legends/', 'Config/Champions/', 'LeagueClient.exe');
-  }
-  else if (fs.existsSync('C:/Riot Games/League Of Legends/lol.launcher.exe')) {
+  } else if (fs.existsSync('C:/Riot Games/League Of Legends/lol.launcher.exe')) {
     return this.setInstallPath(null, 'C:/Riot Games/League Of Legends/', 'Config/Champions/', 'lol.launcher.exe');
   }
 }
@@ -67,9 +66,8 @@ function checkInstallPath(selected_path, done) {
       done(null, selected_path, 'Game/Config/Champions/', path.basename(garena_check_one));
     } else if (garena_check_two) {
       let garena_version = path.basename(glob.sync(path.join(selected_path, 'GameData/Apps/*'))[0]);
-      done(null, selected_path, 'GameData/Apps/${garena_version}/Game/Config/Champions/', path.basename(garena_check_two));
-    
-	}	else {
+      done(null, selected_path, `GameData/Apps/${garena_version}/Game/Config/Champions/`, path.basename(garena_check_two));
+    } else {
       done(new Error('Path not found'), selected_path);
     }
   }
@@ -96,7 +94,7 @@ function setInstallPath(path_err, install_path, champ_path, executable) {
   }
   function foundLeague() {
     $('#input_msg').addClass('green');
-    $('#input_msg').text('${T.t('found')} League of Legends!');
+    $('#input_msg').text(`${T.t('found')} League of Legends!`);
     return enableBtns();
   }
 

--- a/src/path_manager.js
+++ b/src/path_manager.js
@@ -60,7 +60,7 @@ function checkInstallPath(selected_path, done) {
 
     if (fs.existsSync(new_launcher_path)) {
       done(null, selected_path, 'Config/Champions/', path.basename(new_launcher_path));
-    }else if (fs.existsSync(default_path)) {
+    } else if (fs.existsSync(default_path)) {
       done(null, selected_path, 'Config/Champions/', path.basename(default_path));
     } else if (fs.existsSync(garena_check_one)) {
       done(null, selected_path, 'Game/Config/Champions/', path.basename(garena_check_one));

--- a/src/path_manager.js
+++ b/src/path_manager.js
@@ -54,7 +54,7 @@ function checkInstallPath(selected_path, done) {
     }
   } else {
     const default_path = path.join(selected_path, 'lol.launcher.exe');
-	const new_launcher_path = path.join(selected_path, 'LeagueClient.exe');
+    const new_launcher_path = path.join(selected_path, 'LeagueClient.exe');
     const garena_check_one = path.join(selected_path, 'lol.exe');
     const garena_check_two = glob.sync(path.join(selected_path, 'LoL*Launcher.exe'))[0];
 

--- a/src/path_manager.js
+++ b/src/path_manager.js
@@ -17,10 +17,13 @@ function findInstallPath() {
   if (process.platform === 'darwin') {
     if (fs.existsSync('/Applications/League of Legends.app')) {
       return this.setInstallPath(null, '/Applications/League of Legends.app/', 'Contents/LoL/Config/Champions/');
-    } else if (fs.existsSync(`${user_home}/Applications/League of Legends.app`)) {
-      return this.setInstallPath(null, `${user_home}/Applications/League of Legends.app/`, 'Contents/LoL/Config/Champions/');
+    } else if (fs.existsSync('${user_home}/Applications/League of Legends.app')) {
+      return this.setInstallPath(null, '${user_home}/Applications/League of Legends.app/', 'Contents/LoL/Config/Champions/');
     }
-  } else if (fs.existsSync('C:/Riot Games/League Of Legends/lol.launcher.exe')) {
+  } else if (fs.existsSync('C:/Riot Games/League Of Legends/LeagueClient.exe')) {
+    return this.setInstallPath(null, 'C:/Riot Games/League Of Legends/', 'Config/Champions/', 'LeagueClient.exe');
+  }
+  else if (fs.existsSync('C:/Riot Games/League Of Legends/lol.launcher.exe')) {
     return this.setInstallPath(null, 'C:/Riot Games/League Of Legends/', 'Config/Champions/', 'lol.launcher.exe');
   }
 }
@@ -52,17 +55,21 @@ function checkInstallPath(selected_path, done) {
     }
   } else {
     const default_path = path.join(selected_path, 'lol.launcher.exe');
+	const new_launcher_path = path.join(selected_path, 'LeagueClient.exe');
     const garena_check_one = path.join(selected_path, 'lol.exe');
     const garena_check_two = glob.sync(path.join(selected_path, 'LoL*Launcher.exe'))[0];
 
-    if (fs.existsSync(default_path)) {
+    if (fs.existsSync(new_launcher_path)) {
+      done(null, selected_path, 'Config/Champions/', path.basename(new_launcher_path));
+    }else if (fs.existsSync(default_path)) {
       done(null, selected_path, 'Config/Champions/', path.basename(default_path));
     } else if (fs.existsSync(garena_check_one)) {
       done(null, selected_path, 'Game/Config/Champions/', path.basename(garena_check_one));
     } else if (garena_check_two) {
       let garena_version = path.basename(glob.sync(path.join(selected_path, 'GameData/Apps/*'))[0]);
-      done(null, selected_path, `GameData/Apps/${garena_version}/Game/Config/Champions/`, path.basename(garena_check_two));
-    } else {
+      done(null, selected_path, 'GameData/Apps/${garena_version}/Game/Config/Champions/', path.basename(garena_check_two));
+    
+	}	else {
       done(new Error('Path not found'), selected_path);
     }
   }
@@ -89,7 +96,7 @@ function setInstallPath(path_err, install_path, champ_path, executable) {
   }
   function foundLeague() {
     $('#input_msg').addClass('green');
-    $('#input_msg').text(`${T.t('found')} League of Legends!`);
+    $('#input_msg').text('${T.t('found')} League of Legends!');
     return enableBtns();
   }
 

--- a/tests/path_manager.js
+++ b/tests/path_manager.js
@@ -53,7 +53,7 @@ describe('src/path_manager', () => {
         done();
       });
     });
-	
+
     it('should the correct path for a default League installation - New Launcher', function(done) {
       fs.mkdirsSync('./tmp/0/');
       fs.writeFileSync('./tmp/0/LeagueClient.exe', '123', 'utf8');

--- a/tests/path_manager.js
+++ b/tests/path_manager.js
@@ -53,8 +53,21 @@ describe('src/path_manager', () => {
         done();
       });
     });
+	
+    it('should the correct path for a default League installation - New Launcher', function(done) {
+      fs.mkdirsSync('./tmp/0/');
+      fs.writeFileSync('./tmp/0/LeagueClient.exe', '123', 'utf8');
+      const test_path = path.resolve('./tmp/0/');
+      pathManager.checkInstallPath(test_path, function(err, selected_path, config_dir, executable) {
+        should.not.exist(err);
+        selected_path.should.equal(test_path);
+        config_dir.should.equal('Config/Champions/');
+        executable.should.equal('LeagueClient.exe');
+        done();
+      });
+    });
 
-    it('should the correct path for a default League installation', function(done) {
+    it('should the correct path for a default League installation - Old Launcher', function(done) {
       fs.mkdirsSync('./tmp/1/');
       fs.writeFileSync('./tmp/1/lol.launcher.exe', '123', 'utf8');
       const test_path = path.resolve('./tmp/1/');


### PR DESCRIPTION
Championify now use new launcher first when available.
Also, if the old launcher was deleted, championify was unable to locate LOL (Logic)

