### PR TITLE
2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+<a name="2.0.3" />
+## 2.0.3 (March 2nd, 2017)
+
+#### Bug Fixes
+- Fixed op.gg endpoints [#280](https://github.com/dustinblackman/Championify/issues/280)
+- Allow imports to continue when a source is down [#276](https://github.com/dustinblackman/Championify/issues/276)
+- Fixed issue with progress bar disappearing on a second import
+
 <a name="2.0.2" />
 ## 2.0.2 (January 29th, 2017)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Championify",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Downloads all the recent builds from websites like Champion.gg and imports them in to League of Legends.",
   "main": "electron.js",
   "scripts": {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -59,6 +59,9 @@ export function request(options) {
       .then(res => {
         if (res.statusCode >= 400) throw new ChampionifyErrors.RequestError(res.statusCode, params.url, res.body);
         return res.body;
+      })
+      .catch(err => {
+        throw new ChampionifyErrors.RequestError(err.name, params.url, err);
       });
   }, retry_options);
 }

--- a/src/sources/opgg.js
+++ b/src/sources/opgg.js
@@ -145,7 +145,7 @@ function _makeRequest(url) {
 }
 
 export function getVersion() {
-  return request('http://op.gg/champion/ahri/statistics/mid')
+  return request('https://www.op.gg/champion/ahri/statistics/mid')
     .then(cheerio.load)
     .then($ => R.last($('span.Small').text().split(': ')))
     .tap(version => store.set('opgg_ver', version));
@@ -154,7 +154,7 @@ export function getVersion() {
 export function getSr() {
   if (!store.get('opgg_ver')) return getVersion().then(getSr);
 
-  return _makeRequest('http://op.gg/champion/statistics')
+  return _makeRequest('https://www.op.gg/champion/statistics')
     .then($ => {
       return $('.ChampionIndexGrid')
         .find('.Item')
@@ -175,8 +175,8 @@ export function getSr() {
       cl(`${T.t('processing')} op.gg: ${T.t(champ_data.name)}`);
       return Promise.map(champ_data.positions, position => {
         return Promise.join(
-          _makeRequest(`http://op.gg/champion/${champ_data.name}/statistics/${position}/item`),
-          _makeRequest(`http://op.gg/champion/${champ_data.name}/statistics/${position}/skill`)
+          _makeRequest(`https://www.op.gg/champion/${champ_data.name}/statistics/${position}/item`),
+          _makeRequest(`https://www.op.gg/champion/${champ_data.name}/statistics/${position}/skill`)
         )
         .spread(($i, $s) => {
           const skills = mapSkills($s, csspaths.opgg.skills);

--- a/src/view_manager.js
+++ b/src/view_manager.js
@@ -186,7 +186,7 @@ function mainViewBack() {
   function resetMain() {
     $('#cl_progress').html('');
     $('.submit_btns').removeClass('hidden');
-    $('.status').attr('class', 'status hidden');
+    $('.status').attr('class', 'status');
     _initSettings();
   }
 

--- a/tests/sources/opgg.js
+++ b/tests/sources/opgg.js
@@ -34,7 +34,7 @@ function testWithFixture(fixture) {
 
 describe('src/sources/opgg', () => {
   before(() => {
-    nocked = nock('http://op.gg');
+    nocked = nock('https://www.op.gg');
   });
 
   beforeEach(() => {


### PR DESCRIPTION
- Fixed op.gg endpoints [#280](https://github.com/dustinblackman/Championify/issues/280)
- Allow imports to continue when a source is down [#276](https://github.com/dustinblackman/Championify/issues/276)
- Fixed issue with progress bar disappearing on a second import