### PR TITLE
Updated to allow ARAM/Blitz item sets from Lolalytics and more

### DIFF
--- a/data/prebuilts.json
+++ b/data/prebuilts.json
@@ -49,8 +49,11 @@
     {
       "id": "2139",
       "count": 1
+    },
+    {
+      "id": "2047",
+      "count": 1
     }
-
   ],
   "trinket_upgrades": [
     {

--- a/i18n/_source.json
+++ b/i18n/_source.json
@@ -263,6 +263,14 @@
     "text": "Download ARAM item sets from LolFlavor",
     "done": true
   },
+  "options_aram_blitz_lolalytics": {
+    "text": "Download ARAM Item Sets",
+    "done": true
+  },
+  "options_aram_blitz_lolalytics_tooltip": {
+    "text": "Download ARAM & Blitz item sets from Lolalytics",
+    "done": true
+  },
   "options_consumables": {
     "done": true,
     "text": "Enable Consumables"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -65,6 +65,8 @@
   "open_log": "Open Log",
   "options_aram": "Download ARAM Item Sets",
   "options_aram_tooltip": "Download ARAM item sets from LolFlavor",
+  "options_aram_blitz_lolalytics": "Download ARAM & Blitz Item Sets",
+  "options_aram_blitz_lolalytics_tooltip": "Download ARAM & Blitz item sets from Lolalytics",
   "options_consumables": "Enable Consumables",
   "options_consumables_tooltip": "By disabling consumables, you'll lose the Most Frequent skill order",
   "options_dontdeleteold": "Don't Delete Outdated Item Sets",

--- a/src/championify.js
+++ b/src/championify.js
@@ -127,7 +127,7 @@ function deleteOldBuilds(deletebtn) {
 function fixAndSaveToFile() {
   const special_items = store.get('special_items');
 
-  return Promise.resolve([store.get('sr_itemsets'), store.get('aram_itemsets')])
+  return Promise.resolve([store.get('sr_itemsets'), store.get('aram_itemsets'), store.get('blitz_itemsets')])
     .then(R.flatten)
     .then(R.reject(R.isNil))
     .each(data => {
@@ -205,14 +205,29 @@ function downloadItemSets() {
   store.set('importing', true);
   store.remove('sr_itemsets');
   store.remove('aram_itemsets');
+  store.remove('blitz_itemsets');
   store.remove('undefined_builds');
   progressbar.reset();
 
   const to_process = [];
-  if (store.get('settings').aram) to_process.push({
-    name: 'lolflavor',
-    method: sources.lolflavor.getAram
-  });
+
+  if (store.get('settings').aram) {
+    to_process.push({
+      name: 'lolflavor',
+      method: sources.lolflavor.getAram
+    });
+  }
+  if (store.get('settings').aram_blitz_lolalytics) {
+    to_process.push({
+      name: 'lolalytics',
+      method: sources.lolalytics.getAram
+    });
+    to_process.push({
+      name: 'lolalytics',
+      method: sources.lolalytics.getBlitz
+    });
+  }
+
   R.forEach(source => {
     if (sources[source]) to_process.push({
       name: source,

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -118,7 +118,8 @@ class Preferences {
         locksr: $('#options_locksr').is(':checked'),
         sr_source: $('#options_sr_source').val().split(','),
         dontdeleteold: $('#options_dontdeleteold').is(':checked'),
-        aram: $('#options_aram').is(':checked')
+        aram: $('#options_aram').is(':checked'),
+        aram_blitz_lolalytics: $('#options_aram_blitz_lolalytics').is(':checked')
       }
     };
   }

--- a/src/sources/championgg.js
+++ b/src/sources/championgg.js
@@ -34,10 +34,11 @@ function processSkills(skills) {
 
 function formatForStore(champ, position, set_type, file_prefix, build) {
   let title = T.t(position, true);
+  let site_abbr = (store.get('settings').splititems) ? 'CGG' : 'Champion.gg';
   if (set_type) title += ` ${set_type}`;
   const riot_json = R.merge(default_schema, {
     champion: champ,
-    title: `CGG ${title} ${store.get('championgg_ver')}`,
+    title: `${site_abbr} ${title} ${store.get('championgg_ver')}`,
     blocks: build
   });
 

--- a/src/sources/koreanbuilds.js
+++ b/src/sources/koreanbuilds.js
@@ -123,9 +123,10 @@ export function getSr() {
               }
             ];
 
+            let site_abbr = (store.get('settings').splititems) ? 'KRB' : 'KoreanBuilds';
             const riot_json = R.merge(R.clone(default_schema, true), {
               champion: champ_data.formatted_name,
-              title: `KRB ${role} ${store.get('koreanbuilds_ver')}`,
+              title: `${site_abbr} ${role} ${store.get('koreanbuilds_ver')}`,
               blocks: trinksCon(block, {highest_win: skills, most_freq: skills})
             });
 

--- a/src/sources/lolflavor.js
+++ b/src/sources/lolflavor.js
@@ -97,7 +97,7 @@ function _requestData(champs_names, process_name) {
             riot_json.blocks.shift();
             riot_json.blocks = trinksCon(riot_json.blocks);
           }
-          riot_json.title = `LFV ${T.t(process_name.toLowerCase(), true)} ${spliceVersion(store.get('riot_ver'))}`;
+          riot_json.title = `LolFlavor ${T.t(process_name.toLowerCase(), true)} ${spliceVersion(store.get('riot_ver'))}`;
 
           if (process_name === 'ARAM') {
             progressbar.incrChamp();

--- a/src/sources/lolmasters.js
+++ b/src/sources/lolmasters.js
@@ -48,9 +48,10 @@ function processChampData(champ, lm_position, data) {
     count: 1
   }), item_ids);
 
+  let site_abbr = (store.get('settings').splititems) ? 'LM' : 'LolMasters';
   const riot_json = R.merge(default_schema, {
     champion: champ,
-    title: `LM ${store.get('lolmasters_ver')} ${positions[lm_position]}`,
+    title: `${site_abbr} ${store.get('lolmasters_ver')} ${positions[lm_position]}`,
     blocks: trinksCon([{
       type: positions[lm_position],
       items

--- a/src/sources/opgg.js
+++ b/src/sources/opgg.js
@@ -74,7 +74,7 @@ function formatForStore(champ, position, skills, set_type, file_prefix, blocks) 
   if (set_type) title += ` ${set_type}`;
   const riot_json = R.merge(default_schema, {
     champion: champ,
-    title: `OPGG ${title} ${store.get('opgg_ver')}`,
+    title: `OP.GG ${title} ${store.get('opgg_ver')}`,
     blocks: trinksCon(R.map(R.omit(['rate']), blocks), skills)
   });
 

--- a/views/main.marko
+++ b/views/main.marko
@@ -26,6 +26,10 @@
       </div>
     </div>
     <div class="ui checkbox left">
+      <input id="options_aram_blitz_lolalytics" type="checkbox"/>
+      <label data-content="$!{data.T.t('options_aram_blitz_lolalytics_tooltip')}" class="options_tooltip">$!{data.T.t('options_aram_blitz_lolalytics_tooltip')}</label>
+    </div><br/>
+    <div class="ui checkbox left">
       <input id="options_aram" type="checkbox"/>
       <label data-content="$!{data.T.t('options_aram_tooltip')}" class="options_tooltip">$!{data.T.t('options_aram_tooltip')}</label>
     </div><br/>


### PR DESCRIPTION
* Now has new option that can be checked to import ARAM/Blitz item sets from Lolalytics (some stuff still needs to be tested and worked out, but it seems to work from my initial tests)  
* Now uses the full site names for itemsets that aren't split (since the names are short enough in those cases). I never liked trying to parse the abbreviations because most of them weren't immediately recognizable, so I got rid of them in places they weren't needed (i.e. when item-sets weren't broken up)
* Changed how Lolalytics item set sorting ordering works so that all Most Frequent groups appeared before Highest Win Rate instead of interlacing them because of how those particular item sets are displayed, it makes it very hard to consume. 
* Added Oracle Elixir to consumables list globally since the client will filter unavailable items out anyways. 

Some of this could be cleaned up, I'm sure. I know I could have minimized certain functions, but wanted to match the existing structure as best as I could initially, then planned to change from there. I will likely be adding more to this PR in the next day or so.